### PR TITLE
Fix intro CTA link path

### DIFF
--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -12,6 +12,6 @@
 
 		<ul class="actions">
 			<li><a href="#main" class="button primary icon fa-compass scrolly">Explore stories</a></li>
-			<li><a href="/training/" class="button icon fa-user">Meet Sam</a></li>
+			<li><a href="{{ '/training/' | relative_url }}" class="button icon fa-user">Meet Sam</a></li>
 		</ul>
 </div>


### PR DESCRIPTION
### Motivation
- Ensure the intro page "Meet Sam" button links to the actual training/startup intro page and resolves correctly when the site is served from a subpath by using Jekyll path helpers.

### Description
- Replace the hard-coded `href="/training/"` in `_includes/intro.html` with `{{ '/training/' | relative_url }}` so the generated URL adapts to `site.baseurl` and deployment paths.

### Testing
- Verified the change with `git diff -- _includes/intro.html` (succeeded); attempted to validate Liquid rendering with `ruby -e "require 'liquid' ..."` and to build the site with `bundle exec jekyll build`, but both checks failed in this environment due to missing `liquid` gem and the `jekyll` executable respectively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bde79fd92c8322bdafa991628c17c0)